### PR TITLE
LC 141. Linked List Cycle

### DIFF
--- a/linked_list.py
+++ b/linked_list.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 
-class ListNode:
+class ListNodeWithEqual:
     def __init__(self, val=0, next=None):
         self.val = val
         self.next = next
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, ListNode):
+        if not isinstance(other, ListNodeWithEqual):
             return NotImplemented
         node = self
         while node and other:
@@ -18,8 +18,30 @@ class ListNode:
         return True
 
 
+class ListNode:
+    def __init__(self, val=0, next=None):
+        self.val = val
+        self.next = next
+
+
 class Solution:
-    def reverseList(self, head: Optional[ListNode]) -> Optional[ListNode]:
+    def hasCycle(self, head: Optional[ListNode]) -> bool:
+        if not head:
+            return False
+        turtle, rabbit = head, head.next
+        while rabbit and turtle:
+            if rabbit == turtle:
+                return True
+            if rabbit.next:
+                rabbit = rabbit.next.next
+            else:
+                return False
+            turtle = turtle.next
+        return False
+
+    def reverseList(
+        self, head: Optional[ListNodeWithEqual]
+    ) -> Optional[ListNodeWithEqual]:
         tail = None
         node = head
         while node:

--- a/tests/test_linked_list/test_has_cycle.py
+++ b/tests/test_linked_list/test_has_cycle.py
@@ -1,0 +1,25 @@
+from linked_list import ListNode
+
+
+def test_has_cycle(solution):
+    tail = ListNode(-4)
+    cycle = ListNode(2, ListNode(0, tail))
+    tail.next = cycle
+    head = ListNode(3, cycle)
+    assert solution.hasCycle(head)
+
+
+def test_has_cycle_2(solution):
+    temp = ListNode(2)
+    head = ListNode(1, temp)
+    temp.next = head
+    assert solution.hasCycle(head)
+
+
+def test_has_cycle_3(solution):
+    assert not solution.hasCycle(ListNode(1))
+
+
+def test_has_cycle_edge(solution):
+    assert not solution.hasCycle(None)
+    assert not solution.hasCycle(ListNode(1, ListNode(2, ListNode(3, ListNode(4)))))

--- a/tests/test_linked_list/test_reverse_list.py
+++ b/tests/test_linked_list/test_reverse_list.py
@@ -1,5 +1,5 @@
 import pytest
-from linked_list import ListNode
+from linked_list import ListNodeWithEqual as ListNode
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# LC 141. Linked List Cycle

- Rename the previous `__eq__` implemented `ListNode` to `ListNodeWithEqual` to not confuse
other methods that use original `ListNode`. 
- Implemented Linked List Cycle
